### PR TITLE
Fix TimeZone =~ to work with String patterns

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -341,7 +341,8 @@ module ActiveSupport
     # Compare #name and TZInfo identifier to a supplied regexp, returning +true+
     # if a match is found.
     def =~(re)
-      re === name || re === MAPPING[name]
+      regexp = Regexp === re ? re : /#{Regexp.escape(re.to_s)}/
+      regexp =~ name || regexp =~ MAPPING[name]
     end
 
     # Compare #name and TZInfo identifier to a supplied regexp, returning +true+

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -781,6 +781,12 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert zone !~ /Nonexistent_Place/
   end
 
+  def test_zone_match_with_string
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+    assert zone =~ "Eastern"
+    assert zone !~ "Nonexistent_Place"
+  end
+
   def test_zone_match?
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     assert zone.match?(/Eastern/)


### PR DESCRIPTION
## Summary
- fix `TimeZone#=~` to convert strings to regexes
- test matching TimeZone with string patterns

## Testing
- `bundle exec ruby -Itest activesupport/test/time_zone_test.rb -n test_zone_match_with_string`
- `bundle exec ruby -Itest activesupport/test/time_zone_test.rb -n test_zone_match`
- `bundle exec ruby -Itest activesupport/test/time_zone_test.rb -n test_zone_match\?`


------
https://chatgpt.com/codex/tasks/task_e_68458f19ad0c83278af779d5993bd44d