### PR TITLE
Fix after_fork memory leak in EventedFileUpdateChecker

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -5,6 +5,7 @@ require "listen"
 
 require "pathname"
 require "concurrent/atomic/atomic_boolean"
+require "weakref"
 
 module ActiveSupport
   # Allows you to "listen" to changes in a file system.
@@ -91,8 +92,12 @@ module ActiveSupport
         # inotify / FSEvents file descriptors are inherited on fork, so
         # we need to reopen them otherwise only the parent or the child
         # will be notified.
-        # FIXME: this callback is keeping a reference on the instance
-        @after_fork = ActiveSupport::ForkTracker.after_fork { start }
+        # Use a weak reference so the callback doesn't keep the instance alive,
+        # but still restarts listeners after a fork.
+        weak_self = WeakRef.new(self)
+        @after_fork = ActiveSupport::ForkTracker.after_fork do
+          weak_self.__getobj__.start if weak_self.weakref_alive?
+        end
       end
 
       def finalizer

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -117,6 +117,29 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     assert_empty Thread.list & listener_threads
   end
 
+  test "can be garbage collected after fork" do
+    skip "Forking not available" unless Process.respond_to?(:fork)
+
+    checker_ref, listener_threads = Thread.new do
+      threads_before_checker = Thread.list
+      checker = ActiveSupport::EventedFileUpdateChecker.new([], tmpdir => ".rb") { }
+
+      # Wait for listener thread to start processing events.
+      wait
+
+      pid = fork { exit! }
+      Process.wait(pid)
+
+      [WeakRef.new(checker), Thread.list - threads_before_checker]
+    end.value
+
+    GC.start
+    listener_threads.each { |t| t.join(1) }
+
+    assert_not checker_ref.weakref_alive?, "EventedFileUpdateChecker was not garbage collected"
+    assert_empty Thread.list & listener_threads
+  end
+
   test "should detect changes through symlink" do
     actual_dir = File.join(tmpdir, "actual")
     linked_dir = File.join(tmpdir, "linked")


### PR DESCRIPTION
## Summary
- ensure `after_fork` callback uses `WeakRef` so EventedFileUpdateChecker can be GC'd
- add a regression test covering GC after a fork

## Testing
- `bin/test test/evented_file_update_checker_test.rb -n '/garbage collected/'`
- `bin/test test/evented_file_update_checker_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6845972ec37c83279497bfff0826d3e6