### PR TITLE
Fix dup not preserving attribute changed state

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -252,12 +252,15 @@ module ActiveModel
 
     def init_attributes(other) # :nodoc:
       attrs = super
+
       if self.class.respond_to?(:_default_attributes)
-        self.class._default_attributes.map do |attr|
+        attrs = self.class._default_attributes.map do |attr|
           attr.with_value_from_user(attrs.fetch_value(attr.name))
         end
-      else
-        attrs
+      end
+
+      attrs.map do |attr|
+        other.attribute_changed?(attr.name) ? attr : attr.forgetting_assignment
       end
     end
 

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -423,6 +423,20 @@ class DirtyTest < ActiveRecord::TestCase
     assert_not_predicate pirate_dup, :catchphrase_changed?
   end
 
+  def test_dup_preserves_attribute_changed_state
+    parrot = Parrot.create!(name: "Polly")
+    pirate = Pirate.create!(catchphrase: "shiver me timbers", parrot: parrot)
+    pirate.catchphrase = "Arr!"
+
+    assert_predicate pirate, :catchphrase_changed?
+    assert_not_predicate pirate, :parrot_id_changed?
+
+    pirate_dup = pirate.dup
+
+    assert_predicate pirate_dup, :catchphrase_changed?
+    assert_not_predicate pirate_dup, :parrot_id_changed?
+  end
+
   def test_reverted_changes_are_not_dirty
     phrase = "shiver me timbers"
     pirate = Pirate.create!(catchphrase: phrase)


### PR DESCRIPTION
## Summary
- when duplicating a persisted AR object, preserve changed flags
- test that dup keeps `*_changed?` state

## Testing
- `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/dirty_test.rb -n test_dup_preserves_attribute_changed_state`
- `ARCONN=sqlite3 bundle exec ruby -Iactiverecord/test activerecord/test/cases/dirty_test.rb -n test_dup_objects_should_not_copy_dirty_flag_from_creator`


------
https://chatgpt.com/codex/tasks/task_e_6846cff98f9c832795045d865c30fc8f