### PR TITLE
Fix missing with self-join associations

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -126,10 +126,16 @@ module ActiveRecord
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
           association_conditions = Array(reflection.association_primary_key).index_with(nil)
+          table_name = if reflection.table_name == @scope.table_name
+            reflection.alias_candidate(@scope.table_name)
+          else
+            reflection.table_name
+          end
+
           if reflection.options[:class_name]
             @scope.where!(association => association_conditions)
           else
-            @scope.where!(reflection.table_name => association_conditions)
+            @scope.where!(table_name => association_conditions)
           end
         end
 

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -9,6 +9,8 @@ require "models/comment"
 require "models/categorization"
 require "models/book"
 require "models/cpk"
+require "models/person"
+require "models/friendship"
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
@@ -144,6 +146,11 @@ module ActiveRecord
     def test_missing_with_multiple_association
       assert_predicate posts(:authorless).comments, :empty?
       assert_equal [posts(:authorless)], Post.where.missing(:author, :comments).to_a
+    end
+
+    def test_missing_with_self_referential_through_association
+      person = Person.create!(first_name: "Solo")
+      assert_includes Person.where.missing(:followers), person
     end
 
     def test_missing_merged_with_scope_on_association


### PR DESCRIPTION
## Summary
- ensure `where.missing` respects table alias for self-referential associations
- test self join through association with `Person` and `followers`

## Testing
- `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/relation/where_chain_test.rb -n test_missing_with_self_referential_through_association`

------
https://chatgpt.com/codex/tasks/task_e_6846df5ee8388327bdc3883ba6fd2035