### PR TITLE
Fix inherited model comparison in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -662,7 +662,7 @@ module ActiveRecord
 
     # Allows sort on objects
     def <=>(other_object)
-      if other_object.is_a?(self.class)
+      if other_object.is_a?(self.class) || is_a?(other_object.class)
         to_key <=> other_object.to_key
       else
         super

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -703,6 +703,16 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_comparison_with_inherited_objects_in_array
+    subclass = Class.new(Topic) { self.table_name = "topics" }
+    topic = Topic.create
+    inherited = subclass.create(id: topic.id)
+
+    assert_nothing_raised do
+      [inherited, topic].sort
+    end
+  end
+
   def test_readonly_attributes
     assert_equal [ "title" ], ReadonlyTitlePost.readonly_attributes
 


### PR DESCRIPTION
## Summary
- ensure `<=>` works with subclass instances
- test sorting inherited records

## Testing
- `ruby -Iactiverecord/lib -Iactivesupport/lib -Iactiverecord/test activerecord/test/cases/base_test.rb -n test_comparison_with_inherited_objects_in_array` *(fails: cannot load such file -- i18n)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfd72db883278a8210b422f12cee