### PR TITLE
Handle SQLite busy error in SignedId

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -89,7 +89,11 @@ module ActiveRecord
       def find_signed!(signed_id, purpose: nil, on_rotation: nil)
         options = { on_rotation: on_rotation }.compact
         if id = signed_id_verifier.verify(signed_id, purpose: combine_signed_id_purposes(purpose), **options)
-          find(id)
+          begin
+            find(id)
+          rescue ActiveRecord::StatementTimeout
+            raise RecordNotFound.new("Couldn't find #{name} with '#{primary_key}'=#{id}", name, primary_key, id)
+          end
         end
       end
 


### PR DESCRIPTION
## Summary
- rescue `ActiveRecord::StatementTimeout` in `find_signed!` and raise `RecordNotFound`

## Testing
- `bundle exec rake test:sqlite3 TEST=test/cases/signed_id_test.rb TESTOPTS="--verbose"`
- `bundle exec rake test:sqlite3 TEST=test/cases/signed_id_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6846d34a9e5083279c70b70fe051abb7