### PR TITLE
Fix touch_all on models without timestamp columns

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -987,7 +987,10 @@ module ActiveRecord
     #   Person.where(name: 'David').touch_all
     #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670' WHERE \"people\".\"name\" = 'David'"
     def touch_all(*names, time: nil)
-      update_all model.touch_attributes_with_time(*names, time: time)
+      touch_updates = model.touch_attributes_with_time(*names, time: time)
+      return 0 if touch_updates.empty?
+
+      update_all touch_updates
     end
 
     # Destroys the records by instantiating each

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -304,6 +304,12 @@ class UpdateAllTest < ActiveRecord::TestCase
     assert_equal new_time, developer.updated_at
   end
 
+  def test_touch_all_on_model_without_timestamps_is_noop
+    assert_nothing_raised do
+      assert_equal 0, Recipe.touch_all
+    end
+  end
+
   def test_update_on_relation
     topic1 = TopicWithCallbacks.create! title: "arel", author_name: nil
     topic2 = TopicWithCallbacks.create! title: "activerecord", author_name: nil


### PR DESCRIPTION
## Summary
- avoid errors when a model without timestamps calls `touch_all`
- add regression test for `touch_all` on `Recipe` model that has no timestamp columns

## Testing
- `bundle exec ruby -Iactiverecord/test -Itest activerecord/test/cases/relation/update_all_test.rb -n test_touch_all_on_model_without_timestamps_is_noop` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfd78958832793f8b5eb45885658