### PR TITLE
Fix strict_loading! mode persistence

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -721,7 +721,11 @@ module ActiveRecord
         raise ArgumentError, "The :mode option must be one of [:all, :n_plus_one_only] but #{mode.inspect} was provided."
       end
 
-      @strict_loading_mode = mode
+      if value
+        @strict_loading_mode = mode if mode != :all || !defined?(@strict_loading_mode) || @strict_loading_mode.nil?
+      else
+        @strict_loading_mode = mode if mode != :all
+      end
       @strict_loading = value
     end
 

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -39,6 +39,14 @@ class StrictLoadingTest < ActiveRecord::TestCase
     assert_predicate developer, :strict_loading_n_plus_one_only?
   end
 
+  def test_strict_loading_mode_persists_after_toggle
+    developer = Developer.first
+    developer.strict_loading!(mode: :n_plus_one_only)
+    developer.strict_loading!(false)
+    developer.strict_loading!
+    assert_predicate developer, :strict_loading_n_plus_one_only?
+  end
+
   def test_strict_loading_n_plus_one_only_mode_with_has_many
     developer = Developer.first
     firm = Firm.create!(name: "NASA")


### PR DESCRIPTION
## Summary
- ensure `strict_loading!` preserves existing mode when toggled off
- add a regression test for strict loading mode persistence

## Testing
- `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/strict_loading_test.rb -n test_strict_loading_mode_persists_after_toggle`
- `ARCONN=sqlite3 bundle exec ruby -Itest test/cases/strict_loading_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6846dfd5a67c8327be0d86fa25560842