### PR TITLE
Fix SSLError translation for Trilogy

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -181,7 +181,7 @@ module ActiveRecord
           end
 
           case exception
-          when ::Trilogy::ConnectionClosed, ::Trilogy::EOFError
+          when ::Trilogy::ConnectionClosed, ::Trilogy::EOFError, ::Trilogy::SSLError
             return ConnectionFailed.new(message, connection_pool: @pool)
           when ::Trilogy::Error
             if exception.is_a?(SystemCallError) || exception.message.include?("TRILOGY_INVALID_SEQUENCE_ID")

--- a/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
+++ b/activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb
@@ -427,6 +427,14 @@ class TrilogyAdapterTest < ActiveRecord::TrilogyTestCase
     end
   end
 
+  test "SSLError raises ActiveRecord::ConnectionFailed" do
+    assert_raises(ActiveRecord::ConnectionFailed) do
+      @conn.raw_connection.stub(:query, -> (*) { raise Trilogy::SSLError.new("trilogy_query_recv: SSL Error") }) do
+        @conn.execute("SELECT 1")
+      end
+    end
+  end
+
   test "setting prepared_statements to true raises" do
     assert_raises ArgumentError do
       ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(prepared_statements: true).connect!


### PR DESCRIPTION
## Summary
- translate `Trilogy::SSLError` to `ActiveRecord::ConnectionFailed`
- cover new behavior with test

## Testing
- `bundle exec rubocop activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb`
- `bundle exec rubocop activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb`
- `bundle exec ruby activerecord/bin/test -a trilogy activerecord/test/cases/adapters/trilogy/trilogy_adapter_test.rb` *(fails: unable to connect to /tmp/mysql.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfd576488327a834e319e5cd8611