### PR TITLE
Fix self-join where.missing bug in ActiveRecord

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -126,7 +126,7 @@ module ActiveRecord
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
           association_conditions = Array(reflection.association_primary_key).index_with(nil)
-          if reflection.options[:class_name]
+          if reflection.options[:class_name] || @scope.table_name == reflection.table_name
             @scope.where!(association => association_conditions)
           else
             @scope.where!(reflection.table_name => association_conditions)

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -202,6 +202,10 @@ module ActiveRecord
       assert_predicate Cpk::Book.where.missing(:author), :any?
     end
 
+    def test_missing_with_self_reference_has_many
+      assert_equal 1, Author.where(id: 1).where.missing(:favorite_authors).count
+    end
+
     def test_not_inverts_where_clause
       relation = Post.where.not(title: "hello")
       expected_where_clause = Post.where(title: "hello").where_clause.invert


### PR DESCRIPTION
## Summary
- fix `where.missing` when association joins the model table to itself
- add regression test for self-referential `has_many` via `favorite_authors`

## Testing
- `bundle exec rake test:sqlite3 TEST=test/cases/relation/where_chain_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6846dfd4109883278a41711d915434cd