### PR TITLE
Fix strict loading violation message

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Avoid calling `inspect` on records when building strict loading violation messages.
+    This prevents additional queries triggered by interpolating the record.
+
+    *Codex*
+
 *   Add `affected_rows` to `ActiveRecord::Result`.
 
     *Jenny Shen*

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -342,7 +342,8 @@ module ActiveRecord
       end
 
       def strict_loading_violation_message(owner)
-        message = +"`#{owner}` is marked for strict_loading."
+        klass_name = owner.is_a?(Class) ? owner.name : owner.class.name
+        message = +"`#{klass_name}` is marked for strict_loading."
         message << " The #{polymorphic? ? "polymorphic association" : "#{klass} association"}"
         message << " named `:#{name}` cannot be lazily loaded."
       end


### PR DESCRIPTION
## Summary
- avoid calling inspect on records in strict loading violation message
- note the change in `CHANGELOG`

## Testing
- `bundle exec rake test TEST=test/cases/strict_loading_test.rb TESTOPTS="--seed 12345"` *(fails: connection errors for some databases)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfd6d2488327a9d81083d233ef9d