### PR TITLE
Fix destroy double-call bug

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -451,6 +451,8 @@ module ActiveRecord
     # and #destroy returns +false+.
     # See ActiveRecord::Callbacks for further details.
     def destroy
+      return self if destroyed?
+
       _raise_readonly_record_error if readonly?
       destroy_associations
       @_trigger_destroy_callback ||= persisted? && destroy_row > 0

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1705,4 +1705,16 @@ class QueryConstraintsTest < ActiveRecord::TestCase
   def test_child_class_with_query_constraints_overrides_parents
     assert_equal(["clothing_type", "color", "size"], ClothingItem::Sized.query_constraints_list)
   end
+
+  def test_destroy_is_idempotent
+    developer = Developer.create!(name: "Destroy Me", salary: 1)
+
+    assert_difference("Developer.count", -1) do
+      developer.destroy
+    end
+
+    assert_no_difference("Developer.count") do
+      developer.destroy
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- make `destroy` idempotent
- test destroying a record multiple times

## Testing
- `bundle exec ruby -Itest test/cases/persistence_test.rb -n test_destroy_is_idempotent` *(fails: Connection nil not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfa10a548327bc55739add70287e