### PR TITLE
Fix foreign key removal bug

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1815,7 +1815,19 @@ module ActiveRecord
 
         def foreign_key_for(from_table, **options)
           return unless use_foreign_keys?
-          foreign_keys(from_table).detect { |fk| fk.defined_for?(**options) }
+
+          keys = foreign_keys(from_table)
+
+          if options[:column]
+            expected = Array(options[:column]).map(&:to_s)
+            keys = keys.select { |fk| Array(fk.column) == expected }
+          elsif options[:to_table]
+            default_column = foreign_key_column_for(options[:to_table], "id")
+            matches = keys.select { |fk| fk.column == default_column }
+            keys = matches if matches.any?
+          end
+
+          keys.find { |fk| fk.defined_for?(**options) }
         end
 
         def foreign_key_for!(from_table, to_table: nil, **options)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -63,23 +63,14 @@ module ActiveRecord
         end
 
         def remove_foreign_key(from_table, to_table = nil, **options)
-          return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table, **options.slice(:column))
+          return if options.delete(:if_exists) && !foreign_key_exists?(from_table, to_table, **options.slice(:column))
 
           to_table ||= options[:to_table]
           options = options.except(:name, :to_table, :validate)
+
+          fkey = foreign_key_for!(from_table, to_table: to_table, **options)
+
           foreign_keys = foreign_keys(from_table)
-
-          fkey = foreign_keys.detect do |fk|
-            table = to_table || begin
-              table = options[:column].to_s.delete_suffix("_id")
-              Base.pluralize_table_names ? table.pluralize : table
-            end
-            table = strip_table_name_prefix_and_suffix(table)
-            options = options.slice(*fk.options.keys)
-            fk_to_table = strip_table_name_prefix_and_suffix(fk.to_table)
-            fk_to_table == table && options.all? { |k, v| fk.options[k].to_s == v.to_s }
-          end || raise(ArgumentError, "Table '#{from_table}' has no foreign key for #{to_table || options}")
-
           foreign_keys.delete(fkey)
           alter_table(from_table, foreign_keys)
         end

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -468,6 +468,19 @@ if ActiveRecord::Base.lease_connection.supports_foreign_keys?
             @connection.foreign_keys("astronauts").map { |fk| [fk.from_table, fk.to_table, fk.column] }
         end
 
+        def test_remove_foreign_key_prefers_default_column
+          @connection.add_column :astronauts, :backup_rocket_id, :bigint
+
+          @connection.add_foreign_key :astronauts, :rockets, column: :rocket_id
+          @connection.add_foreign_key :astronauts, :rockets, column: :backup_rocket_id
+
+          @connection.remove_foreign_key :astronauts, :rockets
+
+          foreign_keys = @connection.foreign_keys(:astronauts)
+          assert_equal 1, foreign_keys.size
+          assert_equal "backup_rocket_id", foreign_keys.first.column
+        end
+
         def test_remove_foreign_key_with_restrict_action
           @connection.add_foreign_key :astronauts, :rockets, on_delete: :restrict
           assert_equal 1, @connection.foreign_keys("astronauts").size


### PR DESCRIPTION
## Summary
- ensure `remove_foreign_key` removes the correct reference when multiple foreign keys reference the same table
- add a regression test

## Testing
- `bundle exec rake test:sqlite3 TEST=test/cases/migration/foreign_key_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6846e3b34a2083278014307272891db3