### PR TITLE
Fix where.missing self join alias

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -126,11 +126,7 @@ module ActiveRecord
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
           association_conditions = Array(reflection.association_primary_key).index_with(nil)
-          if reflection.options[:class_name]
-            @scope.where!(association => association_conditions)
-          else
-            @scope.where!(reflection.table_name => association_conditions)
-          end
+          @scope.where!(association => association_conditions)
         end
 
         @scope

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -9,6 +9,8 @@ require "models/comment"
 require "models/categorization"
 require "models/book"
 require "models/cpk"
+require "models/person"
+require "models/friendship"
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
@@ -200,6 +202,11 @@ module ActiveRecord
       Cpk::Book.create!(id: [1, 2])
 
       assert_predicate Cpk::Book.where.missing(:author), :any?
+    end
+
+    def test_missing_with_self_has_many
+      Person.create!(first_name: "test-first-name")
+      assert_equal 1, Person.where.missing(:friends).count
     end
 
     def test_not_inverts_where_clause

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -11,6 +11,7 @@ class Person < ActiveRecord::Base
                                     through: :readers, source: :post
 
   has_many :friendships, foreign_key: "friend_id"
+  has_many :friends, through: :friendships
   # friends_too exists to test a bug, and probably shouldn't be used elsewhere
   has_many :friends_too, foreign_key: "friend_id", class_name: "Friendship"
   has_many :followers, through: :friendships


### PR DESCRIPTION
## Summary
- fix `where.missing` to use association alias
- add regression test for self join through association
- declare `Person` `has_many :friends`

## Testing
- `bundle exec rake test TEST=test/cases/relation/where_chain_test.rb` *(fails: Could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_6846e3b6cbc08327859362cd1dc8babb