### PR TITLE
Fix enum duplication validation

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -367,6 +367,10 @@ module ActiveRecord
           if values.any?(&:blank?)
             raise ArgumentError, "Enum values #{values} must not contain a blank name."
           end
+
+          if values.map(&:to_s).uniq.length != values.length
+            raise ArgumentError, "Enum values #{values} must not contain duplicate names."
+          end
         else
           raise ArgumentError, "Enum values #{values} must be either a non-empty hash or an array."
         end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -512,6 +512,17 @@ class EnumTest < ActiveRecord::TestCase
     assert_match(/must be either a non-empty hash or an array\.$/, e.message)
   end
 
+  test "duplicate enum names raise an ArgumentError" do
+    e = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = "books"
+        enum :status, [:drafted, :published, :drafted]
+      end
+    end
+
+    assert_match(/must not contain duplicate names\.$/, e.message)
+  end
+
   test "reserved enum names" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"


### PR DESCRIPTION
## Summary
- add validation to prevent duplicate names for enum arrays
- test duplicate enum names raise an error

## Testing
- `bundle exec rake test_sqlite3 TEST=test/cases/enum_test.rb TESTOPTS="--seed=12345"` *(fails: The path `/workspace/rails/vendor/bundle/ruby/3.2.0/bundler/gems/sdoc-cd75e36ce2d1` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6846e3b8e73c83279809c96efb548579