### PR TITLE
Fix preview command error handling

### DIFF
--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -79,7 +79,11 @@ module ActiveStorage
         to.binmode
 
         open_tempfile do |err|
-          IO.popen(argv, err: err) { |out| IO.copy_stream(out, to) }
+          begin
+            IO.popen(argv, err: err) { |out| IO.copy_stream(out, to) }
+          rescue Errno::ENOENT => e
+            raise PreviewError, e.message
+          end
           err.rewind
 
           unless $?.success?


### PR DESCRIPTION
## Summary
- handle missing preview commands gracefully

## Testing
- `bin/test test/previewer/poppler_pdf_previewer_test.rb` *(fails: No such file or directory - pdftoppm)*

------
https://chatgpt.com/codex/tasks/task_e_6846e414cd2c8327884fd2a2d4348238