### PR TITLE
Fix ActiveJob locale serialization

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -109,6 +109,7 @@ module ActiveJob
       @executions = 0
       @exception_executions = {}
       @timezone   = Time.zone&.name
+      @locale     = I18n.locale.to_s
     end
     ruby2_keywords(:initialize)
 
@@ -124,7 +125,7 @@ module ActiveJob
         "arguments"  => serialize_arguments_if_needed(arguments),
         "executions" => executions,
         "exception_executions" => exception_executions,
-        "locale"     => I18n.locale.to_s,
+        "locale"     => (locale || I18n.locale).to_s,
         "timezone"   => timezone,
         "enqueued_at" => Time.now.utc.iso8601(9),
         "scheduled_at" => scheduled_at ? scheduled_at.utc.iso8601(9) : nil,

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -21,6 +21,14 @@ class JobSerializationTest < ActiveSupport::TestCase
     assert_equal "en", HelloJob.new.serialize["locale"]
   end
 
+  test "serialize uses job locale when set" do
+    job = HelloJob.new
+    job.locale = :de
+    I18n.with_locale(:en) do
+      assert_equal "de", job.serialize["locale"]
+    end
+  end
+
   test "serialize and deserialize are symmetric" do
     # Ensure `enqueued_at` does not change between serializations
     freeze_time


### PR DESCRIPTION
## Summary
- ensure `ActiveJob::Base` captures the current locale during initialization
- serialize job using its locale if set
- test that job locale is respected when serializing

## Testing
- `bin/test test/cases/job_serialization_test.rb -n "serialize uses job locale when set"`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6846e3e2a0308327bda3b5fb425c2310