### PR TITLE
Fix DiskService path traversal

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -99,6 +99,9 @@ module ActiveStorage
     end
 
     def path_for(key) # :nodoc:
+      if key.include?("..") || key.start_with?("/") || key.start_with?("\\")
+        raise ArgumentError, "invalid key"
+      end
       File.join root, folder_for(key), key
     end
 

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -78,4 +78,10 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   ensure
     @service.root = tmp_config.dig(:tmp, :root)
   end
+
+  test "path_for rejects traversal" do
+    assert_raises ArgumentError do
+      @service.send(:path_for, "../evil")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- harden `DiskService` path handling
- test path traversal behavior

## Testing
- `bin/test test/service/disk_service_test.rb test/models/filename_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6846e41389fc8327ae8d3c82618c6120