### PR TITLE
Fix expand_cache_key for grouped relations

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -494,7 +494,7 @@ module ActiveRecord
           column = c.visitor.compile(table[timestamp_column])
           select_values = "COUNT(*) AS #{model.adapter_class.quote_column_name("size")}, MAX(%s) AS timestamp"
 
-          if collection.has_limit_or_offset?
+          if collection.has_limit_or_offset? || collection.group_values.any?
             query = collection.select("#{column} AS collection_cache_key_timestamp")
             query._select!(table[Arel.star]) if distinct_value && collection.select_values.empty?
             subquery_alias = "subquery_for_cache_key"

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -291,6 +291,22 @@ module ActiveRecord
       end
     end
 
+    test "cache_key changes when grouped relation updates a non first record" do
+      Developer.delete_all
+      Developer.create!(name: "first")
+      second = Developer.create!(name: "second")
+      Developer.create!(name: "third")
+
+      cache_key = Developer.group(:id).cache_key
+
+      travel 1.second
+      second.touch
+
+      new_key = Developer.group(:id).cache_key
+
+      assert_not_equal cache_key, new_key
+    end
+
     def with_collection_cache_versioning(value = true)
       @old_collection_cache_versioning = ActiveRecord::Base.collection_cache_versioning
       ActiveRecord::Base.collection_cache_versioning = value


### PR DESCRIPTION
## Summary
- prevent incorrect cache version when a relation has grouping
- add a regression test for grouped relations

## Testing
- `bundle exec rake sqlite3:test TEST=test/cases/collection_cache_key_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_68476bc33bf083279869c59799c68afb