### PR TITLE
Add custom PredicateName cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-md
+require:
+  - tools/rubocop/cop/custom/predicate_name_without_side_effect.rb
 
 AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
@@ -408,3 +410,9 @@ Markdown:
   WarnInvalid: true
   # Whether to lint codeblocks without code attributes
   Autodetect: false
+
+Naming/PredicateName:
+  Enabled: false
+
+Custom/PredicateNameWithoutSideEffect:
+  Enabled: true

--- a/tools/rubocop/cop/custom/predicate_name_without_side_effect.rb
+++ b/tools/rubocop/cop/custom/predicate_name_without_side_effect.rb
@@ -1,0 +1,69 @@
+module RuboCop
+  module Cop
+    module Custom
+      # Enhanced version of Naming/PredicateName that skips methods
+      # containing side effects unrelated to the returned value.
+      #
+      # This is a simplified heuristic implementation based on the idea that
+      # predicate methods should be free of side effects. When a method body
+      # contains statements that do not contribute to the final boolean result,
+      # the cop will consider it not a predicate.
+      class PredicateNameWithoutSideEffect < RuboCop::Cop::Naming::PredicateName
+        def on_def(node)
+          return if side_effect_method?(node)
+
+          super
+        end
+        alias on_defs on_def
+
+        private
+
+        def side_effect_method?(node)
+          body = node.body
+          return false unless body
+
+          statements = body.begin_type? ? body.children : [body]
+          return false if statements.size <= 1
+
+          last = statements.last
+          used_vars = variables_in(last)
+
+          statements[0..-2].any? do |stmt|
+            if assignment_to_used_var?(stmt, used_vars)
+              used_vars.concat(variables_assigned(stmt))
+              false
+            else
+              true
+            end
+          end
+        end
+
+        def variables_in(node)
+          node.each_descendant(:lvar, :ivar, :cvar, :gvar).map(&:value)
+        end
+
+        def variables_assigned(node)
+          case node.type
+          when :lvasgn, :ivasgn, :cvasgn, :gvasgn
+            [node.children.first]
+          when :masgn
+            node.lhs.children.map { |n| n.children.first }
+          else
+            []
+          end
+        end
+
+        def assignment_to_used_var?(node, vars)
+          case node.type
+          when :lvasgn, :ivasgn, :cvasgn, :gvasgn
+            vars.include?(node.children.first)
+          when :masgn
+            node.lhs.children.any? { |n| vars.include?(n.children.first) }
+          else
+            false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a custom RuboCop cop to ignore predicate naming for methods with side effects
- enable the custom cop in RuboCop config and disable `Naming/PredicateName`

## Testing
- `ruby -c tools/rubocop/cop/custom/predicate_name_without_side_effect.rb`
- `bundle exec rubocop -V` *(fails: Could not find prism-1.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_684e8aab6e088327ac64b80767997e89